### PR TITLE
WP CLI: add 'version' command

### DIFF
--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -57,6 +57,14 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
 	}
 
+	protected function table( $items, $columns ) {
+		\WP_CLI\Utils\format_items( 'table', $items, $columns );
+
+		if ( ! empty( $this->timestamp ) ) {
+			$this->log( sprintf( 'Generated at %s', $this->output_timestamp() ) );
+		}
+	}
+
 	/**
 	 * Print timestamp to CLI, if enabled.
 	 *

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -12,11 +12,11 @@ class ActionScheduler_Versions {
 	private $versions = array();
 
 	public function register( $version_string, $initialization_callback ) {
-		if ( isset($this->versions[$version_string]) ) {
-			return FALSE;
+		if ( ! isset($this->versions[$version_string]) ) {
+			$this->versions[$version_string] = array();
 		}
-		$this->versions[$version_string] = $initialization_callback;
-		return TRUE;
+		$this->versions[$version_string][] = $initialization_callback;
+		return count( $this->versions[$version_string] ) < 2;
 	}
 
 	public function get_versions() {
@@ -37,7 +37,7 @@ class ActionScheduler_Versions {
 		if ( empty($latest) || !isset($this->versions[$latest]) ) {
 			return '__return_null';
 		}
-		return $this->versions[$latest];
+		return $this->versions[$latest][0];
 	}
 
 	/**
@@ -59,4 +59,3 @@ class ActionScheduler_Versions {
 		call_user_func($self->latest_version_callback());
 	}
 }
- 

--- a/classes/ActionScheduler_WPCLI.php
+++ b/classes/ActionScheduler_WPCLI.php
@@ -43,4 +43,20 @@ class ActionScheduler_WPCLI extends WP_CLI_Command {
 		$command->execute();
 	}
 
+	/**
+	 * Get Action Scheduler version(s)
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : Prints a table of all registered versions.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 */
+	public function version( $args, $assoc_args ) {
+		$command = new ActionScheduler_WPCLI_Command_Version( $args, $assoc_args );
+		$command->execute();
+	}
+
 }

--- a/classes/ActionScheduler_WPCLI_Command_Version.php
+++ b/classes/ActionScheduler_WPCLI_Command_Version.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * WP CLI command to get Action Scheduler versions.
+ */
+class ActionScheduler_WPCLI_Command_Version extends ActionScheduler_Abstract_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 */
+	public function execute() {
+		$all = (bool) \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'all', false );
+		$helper = ActionScheduler_Versions::instance();
+
+		if ( $all ) {
+			$this->print_all( $helper->get_versions() );
+		} else {
+			$this->log( $helper->latest_version() );
+		}
+	}
+
+	/**
+	 * Print table of versions.
+	 */
+	protected function print_all( $versions ) {
+		$versions = array_keys( $versions );
+		usort( $versions, 'version_compare' );
+
+		$items = array();
+
+		foreach ( $versions as $version ) {
+			$items[] = array(
+				'version' => $version
+			);
+		}
+
+		$this->table( $items, 'version' );
+	}
+
+}


### PR DESCRIPTION
Add WP CLI `version` command. Depends on #265 (PR #267).